### PR TITLE
refactor: zoom-image migrate with gsap

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,9 @@
       "name": "front-playground",
       "version": "0.1.0",
       "dependencies": {
+        "@gsap/react": "^2.1.1",
         "clsx": "^2.1.1",
+        "gsap": "^3.12.5",
         "next": "14.2.5",
         "react": "^18",
         "react-dom": "^18",
@@ -91,6 +93,15 @@
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@gsap/react": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@gsap/react/-/react-2.1.1.tgz",
+      "integrity": "sha512-apGPRrmpqxvl1T6Io1KgT8tFU+IuACI6z4zmT7t8+PASserJeLVRFJdSNUFA2Xb/eVkZI1noE8LIrY/w/oJECw==",
+      "dependencies": {
+        "gsap": "^3.12.5",
+        "react": ">=16"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -2327,6 +2338,11 @@
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true
+    },
+    "node_modules/gsap": {
+      "version": "3.12.5",
+      "resolved": "https://registry.npmjs.org/gsap/-/gsap-3.12.5.tgz",
+      "integrity": "sha512-srBfnk4n+Oe/ZnMIOXt3gT605BX9x5+rh/prT2F1SsNJsU1XuMiP0E2aptW481OnonOGACZWBqseH5Z7csHxhQ=="
     },
     "node_modules/has-bigints": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@gsap/react": "^2.1.1",
     "clsx": "^2.1.1",
+    "gsap": "^3.12.5",
     "next": "14.2.5",
     "react": "^18",
     "react-dom": "^18",

--- a/src/components/zoom-image.tsx
+++ b/src/components/zoom-image.tsx
@@ -1,8 +1,10 @@
 'use client'
 
 import { cn } from '@/utils/cn'
+import { useGSAP } from '@gsap/react'
+import gsap from 'gsap'
 import Image from 'next/image'
-import { HTMLAttributes, useLayoutEffect, useState } from 'react'
+import { HTMLAttributes, useRef } from 'react'
 
 interface ZoomImageProps extends HTMLAttributes<HTMLDivElement> {
   src: string
@@ -24,34 +26,20 @@ const ZoomImage = ({
   duration,
   className,
 }: ZoomImageProps) => {
-  const [scale, setScale] = useState(1)
-  const [position, setPosition] = useState({ x: 0, y: 0 })
+  const imageRef = useRef<HTMLImageElement>(null)
 
-  useLayoutEffect(() => {
-    const startTime = Date.now()
-    const initialX = 0
-    const initialY = 0
-
-    const animate = () => {
-      const elapsedTime = Date.now() - startTime
-      const progress = Math.min(elapsedTime / duration, 1)
-
-      const easeProgress = easeOutCubic(progress)
-
-      const newScale = 1 + (maxZoom - 1) * easeProgress
-      const newX = initialX + (targetX - 50) * easeProgress
-      const newY = initialY + (targetY - 50) * easeProgress
-
-      setScale(newScale)
-      setPosition({ x: newX, y: newY })
-
-      if (progress < 1) {
-        requestAnimationFrame(animate)
-      }
+  useGSAP(() => {
+    if (imageRef.current) {
+      gsap.to(imageRef.current, {
+        scale: maxZoom,
+        x: (-(targetX - 50) * width) / 100,
+        y: ((targetY - 50) * height) / 100,
+        duration: duration / 1000,
+        ease: 'power3.inOut',
+        delay: 1,
+      })
     }
-
-    animate()
-  }, [targetX, targetY, maxZoom, duration])
+  }, [])
 
   return (
     <div
@@ -62,11 +50,11 @@ const ZoomImage = ({
       }}
     >
       <Image
+        ref={imageRef}
         src={src}
         fill
-        alt="Zooming image"
+        alt=""
         style={{
-          transform: `scale(${scale}) translate(${-position.x}%, ${-position.y}%)`,
           transformOrigin: 'center',
         }}
       />
@@ -75,7 +63,3 @@ const ZoomImage = ({
 }
 
 export default ZoomImage
-
-function easeOutCubic(t: number): number {
-  return 1 - Math.pow(1 - t, 3)
-}


### PR DESCRIPTION
사용예시

```tsx
import ZoomImage from '@/components/zoom-image'

export default function Home() {
  return (
    <div>
      <ZoomImage
        src="/jung.png"
        width={960}
        height={500}
        targetX={-240}
        targetY={300}
        maxZoom={8}
        duration={1000}
      />
    </div>
  )
}
```